### PR TITLE
#36 Removed need for PROJECT_ROOT env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,5 @@
-PROJECT_ROOT="/workspace/static-website-azure-oid"
-
 # Reguired to authenticate GitHub CLI.
 GITHUB_TOKEN="V3Fg8ezGxseOwvAcCcRZzQKiJuJErsrZoEXAMPLE"
 
 # The Azure resource group the static website belongs to.
-RESOURCE_GROUP="terraform-beginner-bootcamp-2023-azure"
+RESOURCE_GROUP="rg-appname-prod-dfe4wf34"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,12 +1,12 @@
 tasks:
   - name: gh-cli
     before: |
-      cd $PROJECT_ROOT
+      cd $GITPOD_REPO_ROOT
       source ./bin/install-gh-cli.sh
       gp sync-done gh-cli
   - name: azure-cli
     before: |
-      cd $PROJECT_ROOT
+      cd $GITPOD_REPO_ROOT
       gp sync-await gh-cli && source ./bin/install-azure-cli.sh
 vscode:
   extensions:

--- a/bin/install-azure-cli.sh
+++ b/bin/install-azure-cli.sh
@@ -2,7 +2,7 @@
 
 # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions
 
-cd /workspace || exit
+pushd /workspace || exit
 
 # Get packages needed for the installation process:
 sudo apt-get update
@@ -24,6 +24,6 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microso
 sudo apt-get update
 sudo apt-get install azure-cli
 
-cd "$PROJECT_ROOT" || exit
+popd || exit
 
 az login --use-device-code

--- a/bin/install-gh-cli.sh
+++ b/bin/install-gh-cli.sh
@@ -2,7 +2,7 @@
 
 # https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt
 
-cd /workspace || exit
+pushd /workspace || exit
 
 type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
@@ -11,6 +11,6 @@ curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo 
 && sudo apt update \
 && sudo apt install gh -y
 
-cd "$PROJECT_ROOT" || exit
+popd || exit 
 
 gh auth status

--- a/docs/gitpod-development-environment.md
+++ b/docs/gitpod-development-environment.md
@@ -68,7 +68,7 @@ Setting user-specific environment variables
 Using the command: gp env
 
 ```bash
-gp env PROJECT_ROOT='/workspace/static-website-azure-oidc'
+gp env GITHUB_TOKEN="ghp_EXAMPLEcT84BctglVjwRvzN4Qc2PkEXAMPLE"
 ```
 
 Beware that this does not modify your current terminal session, but rather persists this variable for the next workspace on this repository. gp can only interact with the persistent environment variables for this repository, not the environment variables of your terminal. If you want to set that environment variable in your terminal, you can do so using -e:


### PR DESCRIPTION
- [x] Removed dependency on environment variable 'PROJECT_ROOT' needing to be set.
- [x] Updated .gitpod.yml to use 'GITPOD_REPO_ROOT' instead of  'PROJECT_ROOT'
- [x] Updated 'bin/install-azure-cli.sh' to use pushd and popd
- [x] Updated 'bin/install-gh-cli.sh' to use pushd and popd
- [x] Removed  'PROJECT_ROOT' from .env.example
- [x] Updated 'docs/gitpod-development-environment.md'